### PR TITLE
docs: add missing brew command for iOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ flutter build apk
 
 For iOS:
 ````
+brew install automake libtool
 ./build_ffi_ios.sh
 flutter build ipa
 ````


### PR DESCRIPTION
Partial #42 fix