### PR TITLE
ENV-256: fix transactions not showing in activity

### DIFF
--- a/lib/business/notifications.dart
+++ b/lib/business/notifications.dart
@@ -68,6 +68,7 @@ class Notifications {
   }
 
   _checkForNotificationsToAdd() {
+    bool _notificationsAdded = false;
     for (var account in AccountManager().accounts) {
       for (var tx in account.wallet.transactions) {
         if ((tx.date.isAfter(lastUpdated) || !tx.isConfirmed) &&
@@ -89,12 +90,16 @@ class Notifications {
                 tx.txId,
                 amount: tx.amount,
                 walletName: account.wallet.name));
+
+            _notificationsAdded = true;
           }
         }
       }
     }
 
-    lastUpdated = DateTime.now();
+    if (_notificationsAdded) {
+      lastUpdated = DateTime.now();
+    }
   }
 
   deleteFromAccount(Account account) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.7+17
+version: 1.0.7+18
 
 
 environment:


### PR DESCRIPTION
`lastUpdated` was set on each run of `checkForNotificationsToAdd`. In case a transaction was confirmed with an earlier timestamp it would slip through and never be shown on the activity screen.