### PR TITLE
ENV-275: fix iOS libs

### DIFF
--- a/build_ffi_ios.sh
+++ b/build_ffi_ios.sh
@@ -8,8 +8,10 @@
 set -e
 
 # iOS
-rustup target add aarch64-apple-ios
-cargo build --target=aarch64-apple-ios
+rustup install 1.64.0
+rustup +1.64.0 target add aarch64-apple-ios
+cargo +1.64.0 build --target=aarch64-apple-ios
+cargo +1.64.0 build --target=aarch64-apple-ios --release
 
 # iOS simulator
 # (This'll work when https://github.com/alexcrichton/openssl-src-rs/pull/131 is merged/released)

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,14 +10,14 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		78CFC73D291BC26500A3AFDC /* libwallet_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3761627F831E5005559E4 /* libwallet_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
-		78CFC73E291BC26900A3AFDC /* libur_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3761427F831DC005559E4 /* libur_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
-		78CFC73F291BC26D00A3AFDC /* libtor_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3761227F831D5005559E4 /* libtor_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
-		78CFC740291BC27000A3AFDC /* libhttp_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3761027F831CA005559E4 /* libhttp_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
 		78CFC741291BC27300A3AFDC /* libwallet_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3760E27F831B4005559E4 /* libwallet_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
 		78CFC742291BC27600A3AFDC /* libur_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3760C27F831AC005559E4 /* libur_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
 		78CFC743291BC27D00A3AFDC /* libtor_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3760A27F831A3005559E4 /* libtor_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
 		78CFC744291BC28300A3AFDC /* libhttp_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C3760827F83192005559E4 /* libhttp_ffi.a */; settings = {ATTRIBUTES = (Weak, ); }; };
+		78CFC76A292E5CE000A3AFDC /* libhttp_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78CFC766292E5CDF00A3AFDC /* libhttp_ffi.a */; };
+		78CFC76B292E5CE000A3AFDC /* libwallet_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78CFC767292E5CDF00A3AFDC /* libwallet_ffi.a */; };
+		78CFC76C292E5CE000A3AFDC /* libtor_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78CFC768292E5CDF00A3AFDC /* libtor_ffi.a */; };
+		78CFC76D292E5CE000A3AFDC /* libur_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78CFC769292E5CDF00A3AFDC /* libur_ffi.a */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -49,10 +49,10 @@
 		78C3760A27F831A3005559E4 /* libtor_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtor_ffi.a; path = "../target/aarch64-apple-ios/debug/libtor_ffi.a"; sourceTree = "<group>"; };
 		78C3760C27F831AC005559E4 /* libur_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libur_ffi.a; path = "../target/aarch64-apple-ios/debug/libur_ffi.a"; sourceTree = "<group>"; };
 		78C3760E27F831B4005559E4 /* libwallet_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libwallet_ffi.a; path = "../target/aarch64-apple-ios/debug/libwallet_ffi.a"; sourceTree = "<group>"; };
-		78C3761027F831CA005559E4 /* libhttp_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libhttp_ffi.a; path = "../target/aarch64-apple-ios-sim/debug/libhttp_ffi.a"; sourceTree = "<group>"; };
-		78C3761227F831D5005559E4 /* libtor_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtor_ffi.a; path = "../target/aarch64-apple-ios-sim/debug/libtor_ffi.a"; sourceTree = "<group>"; };
-		78C3761427F831DC005559E4 /* libur_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libur_ffi.a; path = "../target/aarch64-apple-ios-sim/debug/libur_ffi.a"; sourceTree = "<group>"; };
-		78C3761627F831E5005559E4 /* libwallet_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libwallet_ffi.a; path = "../target/aarch64-apple-ios-sim/debug/libwallet_ffi.a"; sourceTree = "<group>"; };
+		78CFC766292E5CDF00A3AFDC /* libhttp_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libhttp_ffi.a; path = "../target/aarch64-apple-ios/release/libhttp_ffi.a"; sourceTree = "<group>"; };
+		78CFC767292E5CDF00A3AFDC /* libwallet_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libwallet_ffi.a; path = "../target/aarch64-apple-ios/release/libwallet_ffi.a"; sourceTree = "<group>"; };
+		78CFC768292E5CDF00A3AFDC /* libtor_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtor_ffi.a; path = "../target/aarch64-apple-ios/release/libtor_ffi.a"; sourceTree = "<group>"; };
+		78CFC769292E5CDF00A3AFDC /* libur_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libur_ffi.a; path = "../target/aarch64-apple-ios/release/libur_ffi.a"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		95A836B9AC41F16548DCAC7D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -72,13 +72,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				78CFC741291BC27300A3AFDC /* libwallet_ffi.a in Frameworks */,
-				78CFC73E291BC26900A3AFDC /* libur_ffi.a in Frameworks */,
-				78CFC73D291BC26500A3AFDC /* libwallet_ffi.a in Frameworks */,
+				78CFC76A292E5CE000A3AFDC /* libhttp_ffi.a in Frameworks */,
 				78CFC743291BC27D00A3AFDC /* libtor_ffi.a in Frameworks */,
+				78CFC76D292E5CE000A3AFDC /* libur_ffi.a in Frameworks */,
+				78CFC76C292E5CE000A3AFDC /* libtor_ffi.a in Frameworks */,
 				78CFC744291BC28300A3AFDC /* libhttp_ffi.a in Frameworks */,
 				A32C2D9F135BF88BF0BCD327 /* Pods_Runner.framework in Frameworks */,
-				78CFC73F291BC26D00A3AFDC /* libtor_ffi.a in Frameworks */,
-				78CFC740291BC27000A3AFDC /* libhttp_ffi.a in Frameworks */,
+				78CFC76B292E5CE000A3AFDC /* libwallet_ffi.a in Frameworks */,
 				78CFC742291BC27600A3AFDC /* libur_ffi.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -89,14 +89,14 @@
 		13500A27E223965968B383DF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				78C3761627F831E5005559E4 /* libwallet_ffi.a */,
-				78C3761427F831DC005559E4 /* libur_ffi.a */,
-				78C3761227F831D5005559E4 /* libtor_ffi.a */,
-				78C3761027F831CA005559E4 /* libhttp_ffi.a */,
+				78CFC768292E5CDF00A3AFDC /* libtor_ffi.a */,
+				78CFC769292E5CDF00A3AFDC /* libur_ffi.a */,
 				78C3760E27F831B4005559E4 /* libwallet_ffi.a */,
 				78C3760C27F831AC005559E4 /* libur_ffi.a */,
 				78C3760A27F831A3005559E4 /* libtor_ffi.a */,
 				78C3760827F83192005559E4 /* libhttp_ffi.a */,
+				78CFC766292E5CDF00A3AFDC /* libhttp_ffi.a */,
+				78CFC767292E5CDF00A3AFDC /* libwallet_ffi.a */,
 				4255A42DB2AF56F644919A15 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
@@ -391,11 +391,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = F56X5L36T7;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F56X5L36T7;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -408,23 +407,11 @@
 					"$(inherited)",
 					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
 					/usr/lib/swift,
-				);
-				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(inherited)",
-					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
-					/usr/lib/swift,
-					"../target/aarch64-apple-ios/debug",
-				);
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
-					/usr/lib/swift,
-					"../target/aarch64-apple-ios-sim/debug",
+					"../target/aarch64-apple-ios/release",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.foundationdevices.envoy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = EnvoyAppStoreV2;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = EnvoyProvisioningV3;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -551,11 +538,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = F56X5L36T7;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F56X5L36T7;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -568,23 +554,11 @@
 					"$(inherited)",
 					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
 					/usr/lib/swift,
-				);
-				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(inherited)",
-					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
-					/usr/lib/swift,
 					"../target/aarch64-apple-ios/debug",
-				);
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
-					/usr/lib/swift,
-					"../target/aarch64-apple-ios-sim/debug",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.foundationdevices.envoy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = EnvoyAppStoreV2;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = EnvoyProvisioningV3;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -602,12 +576,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = F56X5L36T7;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F56X5L36T7;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
@@ -617,13 +590,15 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "../target/aarch64-apple-ios/debug";
-				"LIBRARY_SEARCH_PATHS[arch=*]" = "../target/aarch64-apple-ios/debug";
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "../target/aarch64-apple-ios-sim/debug";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\"",
+					/usr/lib/swift,
+					"../target/aarch64-apple-ios/release",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.foundationdevices.envoy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = EnvoyAppStoreV2;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = EnvoyProvisioningV3;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
[https://github.com/rust-lang/rust/pull/100636](https://github.com/rust-lang/rust/pull/100636)

CI gets the latest Rust so when this change hit:
- dynamic libraries for iOS got built
- they basically don’t work
- but they get automatically picked up by Xcode, instead of the static ones I explicitly want
- just because they’re in the same directory

To avoid such trouble in the future I'm stabilising Rust version in the build script to 1.64