### PR TITLE
ENV-279: change duplicate last_error_message name to avoid iOS linker…

### DIFF
--- a/packages/http_tor/lib/http_tor.dart
+++ b/packages/http_tor/lib/http_tor.dart
@@ -121,8 +121,8 @@ Exception _getRustException(String rustError) {
 }
 
 String _lastErrorMessage(DynamicLibrary lib) {
-  final rustFunction =
-      lib.lookup<NativeFunction<LastErrorMessageRust>>('last_error_message');
+  final rustFunction = lib
+      .lookup<NativeFunction<LastErrorMessageRust>>('http_last_error_message');
   final dartFunction = rustFunction.asFunction<LastErrorMessageDart>();
 
   return dartFunction().cast<Utf8>().toDartString();

--- a/packages/http_tor/native/http-ffi/src/lib.rs
+++ b/packages/http_tor/native/http-ffi/src/lib.rs
@@ -62,7 +62,7 @@ pub fn take_last_error() -> Option<Box<dyn Error>> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn last_error_message() -> *const c_char {
+pub unsafe extern "C" fn http_last_error_message() -> *const c_char {
     let last_error = match take_last_error() {
         Some(err) => err,
         None => return CString::new("").unwrap().into_raw(),

--- a/packages/wallet/lib/exceptions.dart
+++ b/packages/wallet/lib/exceptions.dart
@@ -60,8 +60,8 @@ throwRustException(DynamicLibrary lib) {
 }
 
 String _lastErrorMessage(DynamicLibrary lib) {
-  final rustFunction =
-      lib.lookup<NativeFunction<LastErrorMessageRust>>('last_error_message');
+  final rustFunction = lib.lookup<NativeFunction<LastErrorMessageRust>>(
+      'wallet_last_error_message');
   final dartFunction = rustFunction.asFunction<LastErrorMessageDart>();
 
   return dartFunction().cast<Utf8>().toDartString();

--- a/packages/wallet/native/wallet-ffi/src/lib.rs
+++ b/packages/wallet/native/wallet-ffi/src/lib.rs
@@ -116,7 +116,7 @@ pub fn take_last_error() -> Option<Box<dyn Error>> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn last_error_message() -> *const c_char {
+pub unsafe extern "C" fn wallet_last_error_message() -> *const c_char {
     let last_error = match take_last_error() {
         Some(err) => err,
         None => return CString::new("").unwrap().into_raw(),


### PR DESCRIPTION
… problems

When statically linking some XCode versions will default to the -all_load flag which will make it undefined which of the functions gets called at runtime