### PR TITLE
ENV-286-deleting-account-does-not-work 

### DIFF
--- a/lib/business/notifications.dart
+++ b/lib/business/notifications.dart
@@ -103,12 +103,7 @@ class Notifications {
   }
 
   deleteFromAccount(Account account) {
-    for (var notification in notifications) {
-      if (notification.walletName != null &&
-          notification.walletName == account.wallet.name) {
-        notifications.remove(notification);
-      }
-    }
+    notifications.removeWhere((element) => element.walletName == account.name);
   }
 
   //ignore:unused_element


### PR DESCRIPTION
Account deletion gets an exception from notification class. this due to concurrent modification of notification array.   instead of loop we can use removeWhere method to solve the issue