### PR TITLE
Send payjoin

### DIFF
--- a/packages/wallet/native/wallet-ffi/Cargo.toml
+++ b/packages/wallet/native/wallet-ffi/Cargo.toml
@@ -20,6 +20,9 @@ hex = "0.4.3"
 rand = "0.5.6"
 log ="0.4.14"
 bitcoin_hashes = "0.10.0"
+payjoin = { version = "0.5.1-alpha", features = ["sender"] }
+reqwest = { version = "0.11.10", features = ["socks", "blocking"] }
+
 
 [build-dependencies]
 cbindgen = "0.24.3"


### PR DESCRIPTION
Draft logic for sending payjoin. This is NOT a complete design by any means, just a PoC draft to start a conversation and demonstrate the parameters of an integration.

@icota how feasible does payjoin seem too pursue?

## Regarding the design

First, create_payjoin makes an http request which should proxy through http_tor. Payjoin endpoints are often .onion services. Should payjoin functions rather be exposed to a Dart file which then consumes the logic to create the request? native wallet ffi should probably not have a reqwest dependency.

Second, errors are handled with panics here. I see an `error_return` Psbt dummy used for data transport. Is this for the c bindings? Production code should obviously not panic like this PoC does.

I'm curious too hear any feedback you may have